### PR TITLE
Aggiunto Debouncing Software su poll e aggiunto alias al metodo get_value della classe pin

### DIFF
--- a/ablib.py
+++ b/ablib.py
@@ -862,6 +862,8 @@ class Pin():
 	def get_value(self):
 		return get_value(self.kernel_id)
 
+	get = get_value
+
 	def wait_edge(self,fd,callback,debouncingtime):
 		debouncingtime=debouncingtime/1000.0 # converto in millisecondi
 		timestampprec=time.time()


### PR DESCRIPTION
L'alias get = get_value e' utile se si intende usare i tre metodi (on/off/get) indifferentemente su "pin" o su "Daisy19". Ad esempio passo come parametro un oggetto ad una procedura che deve accendere, spengere, interrogare un interruttore,  che potrebbe essere un pin generico o un pin della daisy. In questo modo non devo differenziare i due casi. 

Aggiunto un parametro opzionale a set_edge. Se non specificato il metodo funziona esattamente come prima. Se specificato un valore numerico, che si assume essere un n. di millisecondi, il metodo non richiama una seconda volta la callback() se il tempo trascorso e' inferiore a tale valore. 
(debouncing software di un pulsante)
